### PR TITLE
workflows: update file naming and default tag

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -79,9 +79,9 @@ jobs:
         run: |
           cd build
           mkdir -p artifacts
-          mv merged.hex                   ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_full.hex
-          mv app/zephyr/zephyr.signed.bin ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_update.bin
-          mv app/zephyr/zephyr.elf        ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
+          mv merged.hex                   ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_full.hex
+          mv app/zephyr/zephyr.signed.bin ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_update.bin
+          mv app/zephyr/zephyr.elf        ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
             version:
                 description: 'Release Version.'
                 required: true
-                default: 'template_v0.0.0'
+                default: 'v0.0.0'
                 type: string
 
 jobs:


### PR DESCRIPTION
- Update file naming to remove redundant 'golioth-' prefix since it is already followed by the project name: 'thing91-golioth'.
- Remove 'template_' prefix from the default release tag.