### PR TITLE
README: add python ecdsa package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Install the Python virtual environment (recommended)
    mkdir thingy91-golioth
    python -m venv thingy91-golioth/.venv
    source thingy91-golioth/.venv/bin/activate
-   pip install wheel west
+   pip install wheel west ecdsa
 
 Use ``west`` to initialize and install
 ======================================


### PR DESCRIPTION
Add ecdsa to the pip install command. This package is needed since Golioth Firmware SDK v0.16.0 (probably part of NCS v2.8.0 but unconfirmed). Unfortunately the Zephyr requirements.txt does not include this package.