### PR TITLE
workflow: add mcuboot hex file for thingy91

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -13,7 +13,7 @@ on:
       BOARD:
         required: true
         type: string
-        default: thingy91_nrf9160_ns
+        default: thingy91/nrf9160/ns
       ARTIFACT:
         required: true
         type: boolean
@@ -82,6 +82,10 @@ jobs:
           mv merged.hex                   ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_full.hex
           mv app/zephyr/zephyr.signed.bin ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_update.bin
           mv app/zephyr/zephyr.elf        ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
+
+          if [[ "${{ inputs.BOARD }}" == "thingy91/nrf9160/ns" ]]; then
+            mv app/zephyr/zephyr.signed.hex ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_mcuboot.hex
+          fi
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact


### PR DESCRIPTION
When using the bootloader in DFU mode, a .hex file is needed (not the .bin file that is used for cloud OTA). Add this file to the artifacts automatically included when generating a release.

The bootloader method is currently only tested for the thingy91, not the thingy91X.

Tested on branch: 
![image](https://github.com/user-attachments/assets/0f6d8ec0-5b70-4177-aaa5-38844fcbc04f)

resolves: https://github.com/golioth/devrel-issue-tracker/issues/514