### PR TITLE
CI: add mcuboot update file for thingy91x

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -84,7 +84,11 @@ jobs:
           mv app/zephyr/zephyr.elf        ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
 
           if [[ "${{ inputs.BOARD }}" == "thingy91/nrf9160/ns" ]]; then
+            # Thingy91
             mv app/zephyr/zephyr.signed.hex ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_mcuboot.hex
+          elif [[ "${{ inputs.BOARD }}" == "thingy91x/nrf9151/ns" ]]; then
+            # Thingy91x
+            mv dfu_application.zip ./artifacts/${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_mcuboot.zip
           fi
 
       # Run IDs are unique per repo but are reused on re-runs


### PR DESCRIPTION
This will only run the next time we cut a release, but I tested the build and verified the artifacts here: https://github.com/golioth/thingy91-golioth/actions/runs/19278403529